### PR TITLE
Migrate deployment from App Service to Azure B2s VM

### DIFF
--- a/docker/cloud-init.yaml
+++ b/docker/cloud-init.yaml
@@ -1,0 +1,6 @@
+#cloud-config
+# After VM creation, place storage key in /etc/kunkka-storage.key then run docker/vm-start.sh
+runcmd:
+  - curl -fsSL https://get.docker.com | sh
+  - apt-get install -y cifs-utils -qq
+  - curl -sL https://aka.ms/InstallAzureCLIDeb | bash

--- a/docker/qbittorrent.conf
+++ b/docker/qbittorrent.conf
@@ -1,3 +1,6 @@
+[BitTorrent]
+Session\Port=6881
+
 [LegalNotice]
 Accepted=true
 

--- a/docker/vm-start.sh
+++ b/docker/vm-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Mount Azure File Share (key read from /etc/kunkka-storage.key, placed on VM separately)
+apt-get install -y cifs-utils -qq
+mkdir -p /mnt/kunkka-db-files
+if ! mountpoint -q /mnt/kunkka-db-files; then
+  STORAGE_KEY=$(cat /etc/kunkka-storage.key)
+  mount -t cifs //kunkkatorrentstorage.file.core.windows.net/data /mnt/kunkka-db-files \
+    -o username=kunkkatorrentstorage,password=$STORAGE_KEY,dir_mode=0777,file_mode=0777,nofail
+fi
+echo "File share mounted at /mnt/kunkka-db-files"
+
+# Login to ACR via managed identity
+ARM_TOKEN=$(curl -sf -H 'Metadata:true' 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01&resource=https://management.azure.com/' | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+ACR_TOKEN=$(curl -sf -X POST 'https://kunkkatorrents.azurecr.io/oauth2/exchange' \
+  -d "grant_type=access_token&service=kunkkatorrents.azurecr.io&access_token=$ARM_TOKEN" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["refresh_token"])')
+echo "$ACR_TOKEN" | docker login kunkkatorrents.azurecr.io -u 00000000-0000-0000-0000-000000000000 --password-stdin
+
+# Stop existing container if any
+docker rm -f kunkka-torrent 2>/dev/null || true
+
+docker pull kunkkatorrents.azurecr.io/kunkka-torrent:latest
+docker run -d --name kunkka-torrent --restart unless-stopped \
+  -p 80:80 -p 443:443 -p 6881:6881/tcp -p 6881:6881/udp \
+  -e PORT=80 -e WEBSITE_SITE_NAME=kunkka-torrent \
+  -v /mnt/kunkka-db-files:/mnt/kunkka-db-files \
+  kunkkatorrents.azurecr.io/kunkka-torrent:latest
+echo "Container started successfully"

--- a/publish-vm.bat
+++ b/publish-vm.bat
@@ -1,0 +1,27 @@
+@echo on
+
+set ACR_NAME=kunkkatorrents
+set VM_NAME=kunkka-torrent-vm
+set RESOURCE_GROUP=DefaultResourceGroup-NEU
+set SUBSCRIPTION=3a50dbec-b5b4-4041-b97d-a3125ef48c42
+
+call az acr build --registry %ACR_NAME% --image kunkka-torrent:latest . --subscription %SUBSCRIPTION%
+if %ERRORLEVEL% neq 0 (
+    echo ACR build failed
+    exit /b %ERRORLEVEL%
+)
+
+call az vm run-command invoke ^
+  --resource-group %RESOURCE_GROUP% ^
+  --name %VM_NAME% ^
+  --command-id RunShellScript ^
+  --scripts "@docker\vm-start.sh" ^
+  --subscription %SUBSCRIPTION% ^
+  --query "value[0].message" -o tsv
+if %ERRORLEVEL% neq 0 (
+    echo VM deploy failed
+    exit /b %ERRORLEVEL%
+)
+
+echo Published to VM.
+curl http://20.123.24.242/

--- a/src/server/actions/ScrapeTrackersSeedInfo.ts
+++ b/src/server/actions/ScrapeTrackersSeedInfo.ts
@@ -46,6 +46,21 @@ export const trackerRecords: TrackerRecord[] = [
 
     { url: "udp://tracker1.bt.moack.co.kr:80/announce", maxHashesPerRequest: 50 },
 
+    { url: "udp://tracker.openbittorrent.com:80/announce", maxHashesPerRequest: 75 },
+    { url: "udp://tracker.openbittorrent.com:6969/announce", maxHashesPerRequest: 75 },
+    { url: "udp://open.demonii.com:1337/announce", maxHashesPerRequest: 75 },
+    { url: "udp://tracker.dler.org:6969/announce", maxHashesPerRequest: 75 },
+    { url: "udp://tracker.altrosky.cc:6969/announce", maxHashesPerRequest: 75 },
+    { url: "udp://tracker.bitsearch.to:1337/announce", maxHashesPerRequest: 75 },
+
+    { url: "udp://bt1.archive.org:6969/announce", maxHashesPerRequest: 50 },
+    { url: "udp://bt2.archive.org:6969/announce", maxHashesPerRequest: 50 },
+    { url: "http://tracker.gbitt0.info:80/announce", maxHashesPerRequest: 50 },
+    { url: "https://tracker.gbitt0.info:443/announce", maxHashesPerRequest: 50 },
+    { url: "https://tracker.tamersunion.org:443/announce", maxHashesPerRequest: 50 },
+    { url: "udp://ipv4.tracker.harry.lu:80/announce", maxHashesPerRequest: 50 },
+    { url: "https://opentracker.i2p.rocks:443/announce", maxHashesPerRequest: 50 },
+
     // timeouts often
     //{url: 'udp://tracker0.ufibox.com:6969/announce', maxHashesPerRequest: 75},
 ];


### PR DESCRIPTION
Stupid github deleted my description so I don't care anymore.

- Add publish-vm.bat: builds image in ACR, deploys via az vm run-command
- Add docker/vm-start.sh: mounts Azure File Share, authenticates to ACR via managed identity IMDS token exchange, pulls and starts container
- Update docker/cloud-init.yaml: full VM bootstrap with file share mount and credential-free ACR login via managed identity
- Remove BTProtocol=UTP from qbittorrent.conf (was needed for ACI which could not expose same port on both TCP and UDP; VM supports both)